### PR TITLE
Add generic regex rule for validation

### DIFF
--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRule.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRule.java
@@ -1,0 +1,26 @@
+package com.terminal3.gpcoreui.utils.validator.rules;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validation rule based on a regular expression.
+ */
+public class GPRegexRule extends GPBaseRule {
+    private final Pattern pattern;
+
+    /**
+     * Creates a new regex rule.
+     *
+     * @param regex        Regular expression pattern to match.
+     * @param errorMessage Error message to display when validation fails.
+     */
+    public GPRegexRule(String regex, String errorMessage) {
+        super(errorMessage);
+        this.pattern = Pattern.compile(regex);
+    }
+
+    @Override
+    public boolean isValid(String input) {
+        return input != null && pattern.matcher(input).matches();
+    }
+}

--- a/gpcoreui/src/test/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRuleTest.java
+++ b/gpcoreui/src/test/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRuleTest.java
@@ -1,0 +1,16 @@
+package com.terminal3.gpcoreui.utils.validator.rules;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GPRegexRuleTest {
+    @Test
+    public void emailRegex_validatesCorrectly() {
+        String regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}";
+        GPRegexRule rule = new GPRegexRule(regex, "Invalid email");
+
+        assertTrue(rule.isValid("user@example.com"));
+        assertFalse(rule.isValid("not-an-email"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `GPRegexRule` for pattern-based validation in the validator module
- include unit test for validating email regex

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68884aeb6a808330a83f173b25795445