### PR TITLE
Add customizable button components

### DIFF
--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPOutlinedButton.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPOutlinedButton.java
@@ -1,0 +1,116 @@
+package com.terminal3.gpcoreui.components;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.widget.FrameLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.core.content.ContextCompat;
+
+import com.terminal3.gpcoreui.R;
+import com.terminal3.gpcoreui.enums.GPButtonState;
+
+public class GPOutlinedButton extends FrameLayout {
+
+    private TextView textView;
+    private ProgressBar progressBar;
+    private GPButtonState state = GPButtonState.DEFAULT;
+
+    public GPOutlinedButton(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public GPOutlinedButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+        if (attrs != null) {
+            int[] attrSet = new int[]{android.R.attr.text};
+            android.content.res.TypedArray a = context.obtainStyledAttributes(attrs, attrSet);
+            CharSequence txt = a.getText(0);
+            if (txt != null) {
+                textView.setText(txt);
+            }
+            a.recycle();
+        }
+    }
+
+    public GPOutlinedButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    private void init(Context context) {
+        LayoutInflater.from(context).inflate(R.layout.gp_button, this, true);
+        textView = findViewById(R.id.gp_text);
+        progressBar = findViewById(R.id.gp_progress);
+        setBackground(ContextCompat.getDrawable(context, R.drawable.gp_outlined_button_background));
+        textView.setTextColor(ContextCompat.getColor(context, R.color.gp_text_button_dark));
+        setState(GPButtonState.DEFAULT);
+    }
+
+    public void setText(CharSequence text) {
+        textView.setText(text);
+    }
+
+    public CharSequence getText() {
+        return textView.getText();
+    }
+
+    public void setState(GPButtonState newState) {
+        if (state == newState) return;
+        state = newState;
+        updateState();
+    }
+
+    public GPButtonState getState() {
+        return state;
+    }
+
+    private void updateState() {
+        switch (state) {
+            case INACTIVE:
+                setEnabled(false);
+                progressBar.setVisibility(GONE);
+                textView.setVisibility(VISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_inactive_secondary));
+                break;
+            case LOADING:
+                setEnabled(false);
+                progressBar.setVisibility(VISIBLE);
+                textView.setVisibility(INVISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_dark));
+                break;
+            case PRESS:
+            case DEFAULT:
+            default:
+                setEnabled(true);
+                progressBar.setVisibility(GONE);
+                textView.setVisibility(VISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_dark));
+                break;
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (state == GPButtonState.LOADING || !isEnabled()) {
+            return super.onTouchEvent(event);
+        }
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                setPressed(true);
+                setState(GPButtonState.PRESS);
+                break;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                setPressed(false);
+                setState(GPButtonState.DEFAULT);
+                break;
+        }
+        return super.onTouchEvent(event);
+    }
+}

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPPrimaryButton.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPPrimaryButton.java
@@ -1,0 +1,116 @@
+package com.terminal3.gpcoreui.components;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.widget.FrameLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.core.content.ContextCompat;
+
+import com.terminal3.gpcoreui.R;
+import com.terminal3.gpcoreui.enums.GPButtonState;
+
+public class GPPrimaryButton extends FrameLayout {
+
+    private TextView textView;
+    private ProgressBar progressBar;
+    private GPButtonState state = GPButtonState.DEFAULT;
+
+    public GPPrimaryButton(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public GPPrimaryButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+        if (attrs != null) {
+            int[] attrSet = new int[]{android.R.attr.text};
+            android.content.res.TypedArray a = context.obtainStyledAttributes(attrs, attrSet);
+            CharSequence txt = a.getText(0);
+            if (txt != null) {
+                textView.setText(txt);
+            }
+            a.recycle();
+        }
+    }
+
+    public GPPrimaryButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    private void init(Context context) {
+        LayoutInflater.from(context).inflate(R.layout.gp_button, this, true);
+        textView = findViewById(R.id.gp_text);
+        progressBar = findViewById(R.id.gp_progress);
+        setBackground(ContextCompat.getDrawable(context, R.drawable.gp_primary_button_background));
+        textView.setTextColor(ContextCompat.getColor(context, R.color.gp_text_button_light));
+        setState(GPButtonState.DEFAULT);
+    }
+
+    public void setText(CharSequence text) {
+        textView.setText(text);
+    }
+
+    public CharSequence getText() {
+        return textView.getText();
+    }
+
+    public void setState(GPButtonState newState) {
+        if (state == newState) return;
+        state = newState;
+        updateState();
+    }
+
+    public GPButtonState getState() {
+        return state;
+    }
+
+    private void updateState() {
+        switch (state) {
+            case INACTIVE:
+                setEnabled(false);
+                progressBar.setVisibility(GONE);
+                textView.setVisibility(VISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_inactive_primary));
+                break;
+            case LOADING:
+                setEnabled(false);
+                progressBar.setVisibility(VISIBLE);
+                textView.setVisibility(INVISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_light));
+                break;
+            case PRESS:
+            case DEFAULT:
+            default:
+                setEnabled(true);
+                progressBar.setVisibility(GONE);
+                textView.setVisibility(VISIBLE);
+                textView.setTextColor(ContextCompat.getColor(getContext(), R.color.gp_text_button_light));
+                break;
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (state == GPButtonState.LOADING || !isEnabled()) {
+            return super.onTouchEvent(event);
+        }
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                setPressed(true);
+                setState(GPButtonState.PRESS);
+                break;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                setPressed(false);
+                setState(GPButtonState.DEFAULT);
+                break;
+        }
+        return super.onTouchEvent(event);
+    }
+}

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/GPButtonState.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/GPButtonState.java
@@ -1,0 +1,9 @@
+package com.terminal3.gpcoreui.enums;
+
+public enum GPButtonState {
+    INACTIVE,
+    DEFAULT,
+    PRESS,
+    LOADING
+}
+

--- a/gpcoreui/src/main/res/drawable/gp_outlined_button_background.xml
+++ b/gpcoreui/src/main/res/drawable/gp_outlined_button_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_inactive" />
+            <stroke android:width="1dp" android:color="@color/gp_border_subtle" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_press_primary" />
+            <stroke android:width="1dp" android:color="@color/gp_border_primary" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_default_light" />
+            <stroke android:width="1dp" android:color="@color/gp_border_primary" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/gpcoreui/src/main/res/drawable/gp_primary_button_background.xml
+++ b/gpcoreui/src/main/res/drawable/gp_primary_button_background.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_inactive" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_press_secondary" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gp_bg_default_dark" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/gpcoreui/src/main/res/layout/gp_button.xml
+++ b/gpcoreui/src/main/res/layout/gp_button.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/gp_text"
+        style="@style/GP.Typography.Button1"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center" />
+
+    <ProgressBar
+        android:id="@+id/gp_progress"
+        style="?android:attr/progressBarStyleSmall"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add `GPButtonState` enum
- create `GPPrimaryButton` and `GPOutlinedButton` with loading logic
- provide layout and background drawables

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886ddeb250833090c38abb055a480a