### PR TITLE
Add GPSavedCardView component

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,11 @@
             android:name=".GPFormActivity"
             android:exported="true"
             android:theme="@style/Theme.T3GamePaySDKCoreUI" />
+
+        <activity
+            android:name=".GPSavedCardActivity"
+            android:exported="true"
+            android:theme="@style/Theme.T3GamePaySDKCoreUI" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPSavedCardActivity.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPSavedCardActivity.java
@@ -1,0 +1,18 @@
+package com.terminal3.t3gamepaysdkcoreui;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class GPSavedCardActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_form_host);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.fragmentContainer, new GPSavedCardFragment())
+                    .commit();
+        }
+    }
+}

--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPSavedCardFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPSavedCardFragment.java
@@ -1,0 +1,65 @@
+package com.terminal3.t3gamepaysdkcoreui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.terminal3.gpcoreui.enums.SavedCardState;
+
+import com.terminal3.gpcoreui.components.GPSavedCardView;
+import com.terminal3.gpcoreui.R;
+
+public class GPSavedCardFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_saved_card, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        GPSavedCardView card1 = view.findViewById(R.id.savedCard1);
+        GPSavedCardView card2 = view.findViewById(R.id.savedCard2);
+        GPSavedCardView card3 = view.findViewById(R.id.savedCard3);
+
+        setupCard(card1, "Mastercard Debit", ".... 8217", R.drawable.ic_card_brand_master);
+        setupCard(card2, "Visa Credit", ".... 4242", R.drawable.ic_card_brand_visa);
+        setupCard(card3, "Amex", ".... 1005", R.drawable.ic_card_brand_amex);
+
+        List<GPSavedCardView> cards = new ArrayList<>();
+        cards.add(card1);
+        cards.add(card2);
+        cards.add(card3);
+
+        for (GPSavedCardView card : cards) {
+            card.setOnClickListener(v -> selectCard(card, cards));
+        }
+    }
+
+    private void setupCard(GPSavedCardView card, String name, String number, int iconRes) {
+        card.setCardName(name);
+        card.setMaskedCardNumber(number);
+        card.setCardBrandIcon(ContextCompat.getDrawable(requireContext(), iconRes));
+        card.setState(SavedCardState.DEFAULT);
+    }
+
+    private void selectCard(GPSavedCardView selected, List<GPSavedCardView> allCards) {
+        for (GPSavedCardView card : allCards) {
+            if (card == selected) {
+                card.setState(SavedCardState.SELECTED);
+            } else {
+                card.setState(SavedCardState.DEFAULT);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_saved_card.xml
+++ b/app/src/main/res/layout/fragment_saved_card.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:orientation="vertical">
+
+    <com.terminal3.gpcoreui.components.GPSavedCardView
+        android:id="@+id/savedCard1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/gp_row_spacing" />
+
+    <com.terminal3.gpcoreui.components.GPSavedCardView
+        android:id="@+id/savedCard2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/gp_row_spacing" />
+
+    <com.terminal3.gpcoreui.components.GPSavedCardView
+        android:id="@+id/savedCard3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -11,6 +11,7 @@ This overview lists all widgets included in the `gpcoreui` library. Every class 
 - [GPDynamicForm](components/GPDynamicForm.md)
 - [GPPrimaryButton](components/GPPrimaryButton.md)
 - [GPOutlinedButton](components/GPOutlinedButton.md)
+- [GPSavedCardView](components/GPSavedCardView.md)
 
 Each component document follows the same structure:
 1. Introduction

--- a/docs/components/GPSavedCardView.md
+++ b/docs/components/GPSavedCardView.md
@@ -1,0 +1,42 @@
+# GPSavedCardView
+
+## Overview
+`GPSavedCardView` displays a previously saved payment card. It can be expanded to request the card's CVV before performing a payment.
+
+## Usage
+### XML
+```xml
+<com.terminal3.gpcoreui.components.GPSavedCardView
+    android:id="@+id/savedCard"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### Programmatic
+```java
+GPSavedCardView cardView = findViewById(R.id.savedCard);
+cardView.setCardName("Mastercard Debit");
+cardView.setMaskedCardNumber(".... 8217");
+cardView.setCardBrandIcon(ContextCompat.getDrawable(this, R.drawable.ic_card_brand_master));
+cardView.setState(SavedCardState.SELECTED);
+```
+
+## Attributes
+GPSavedCardView does not define custom XML attributes.
+
+## Methods
+| Method | Description |
+|-------|-------------|
+| `setState(SavedCardState state)` | Change view state between DEFAULT and SELECTED |
+| `getState()` | Retrieve current state |
+| `toggle()` | Convenience method to switch state |
+| `setCardBrandIcon(Drawable drawable)` | Set card brand icon |
+| `setCardName(CharSequence name)` | Set card name label |
+| `setMaskedCardNumber(CharSequence number)` | Set masked card number text |
+| `getCvvField()` | Access the internal `GPCardCVVField` |
+
+## Examples
+See `GPSavedCardFragment` in the sample app for a working example.
+
+## Styling
+The component uses rounded corners and a subtle border. When selected, the background is tinted with `gp_bg_selected_card`.

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPSavedCardView.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPSavedCardView.java
@@ -1,0 +1,97 @@
+package com.terminal3.gpcoreui.components;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
+import com.terminal3.gpcoreui.R;
+import com.terminal3.gpcoreui.enums.SavedCardState;
+
+public class GPSavedCardView extends LinearLayout {
+
+    private ImageView cardBrandView;
+    private TextView cardNameView;
+    private TextView cardNumberView;
+    private ImageView menuView;
+    private GPCardCVVField cvvField;
+    private SavedCardState state = SavedCardState.DEFAULT;
+
+    public GPSavedCardView(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public GPSavedCardView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public GPSavedCardView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    private void init(Context context) {
+        setOrientation(VERTICAL);
+        LayoutInflater.from(context).inflate(R.layout.view_saved_card, this, true);
+        cardBrandView = findViewById(R.id.gp_card_brand);
+        cardNameView = findViewById(R.id.gp_card_name);
+        cardNumberView = findViewById(R.id.gp_card_number);
+        menuView = findViewById(R.id.gp_card_menu);
+        cvvField = findViewById(R.id.gp_cvv_field);
+        setState(SavedCardState.DEFAULT);
+        setOnClickListener(v -> toggle());
+    }
+
+    public void setState(SavedCardState newState) {
+        if (state == newState) return;
+        state = newState;
+        updateState();
+    }
+
+    public SavedCardState getState() {
+        return state;
+    }
+
+    public void toggle() {
+        if (state == SavedCardState.DEFAULT) {
+            setState(SavedCardState.SELECTED);
+        } else {
+            setState(SavedCardState.DEFAULT);
+        }
+    }
+
+    private void updateState() {
+        if (state == SavedCardState.SELECTED) {
+            setBackground(ContextCompat.getDrawable(getContext(), R.drawable.gp_saved_card_background_selected));
+            cvvField.setVisibility(VISIBLE);
+        } else {
+            setBackground(ContextCompat.getDrawable(getContext(), R.drawable.gp_saved_card_background_default));
+            cvvField.setVisibility(GONE);
+        }
+    }
+
+    public void setCardBrandIcon(Drawable drawable) {
+        cardBrandView.setImageDrawable(drawable);
+    }
+
+    public void setCardName(CharSequence name) {
+        cardNameView.setText(name);
+    }
+
+    public void setMaskedCardNumber(CharSequence number) {
+        cardNumberView.setText(number);
+    }
+
+    public GPCardCVVField getCvvField() {
+        return cvvField;
+    }
+}

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/SavedCardState.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/SavedCardState.java
@@ -1,0 +1,6 @@
+package com.terminal3.gpcoreui.enums;
+
+public enum SavedCardState {
+    DEFAULT,
+    SELECTED
+}

--- a/gpcoreui/src/main/res/drawable/gp_saved_card_background_default.xml
+++ b/gpcoreui/src/main/res/drawable/gp_saved_card_background_default.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gp_bg_default_light" />
+    <stroke android:width="1dp" android:color="@color/gp_border_primary" />
+    <corners android:radius="@dimen/gp_saved_card_corner" />
+</shape>

--- a/gpcoreui/src/main/res/drawable/gp_saved_card_background_selected.xml
+++ b/gpcoreui/src/main/res/drawable/gp_saved_card_background_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gp_bg_selected_card" />
+    <stroke android:width="1dp" android:color="@color/gp_border_primary" />
+    <corners android:radius="@dimen/gp_saved_card_corner" />
+</shape>

--- a/gpcoreui/src/main/res/drawable/ic_overflow_menu.xml
+++ b/gpcoreui/src/main/res/drawable/ic_overflow_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#060B14"
+        android:pathData="M12,7a2,2 0 1,0 0,-4a2,2 0 1,0 0,4zM12,14a2,2 0 1,0 0,-4a2,2 0 1,0 0,4zM12,21a2,2 0 1,0 0,-4a2,2 0 1,0 0,4z"/>
+</vector>

--- a/gpcoreui/src/main/res/layout/view_saved_card.xml
+++ b/gpcoreui/src/main/res/layout/view_saved_card.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/gp_saved_card_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/gp_saved_card_padding">
+
+    <LinearLayout
+        android:id="@+id/gp_card_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/gp_card_brand"
+            style="@style/GPIconBackground.Default"
+            android:layout_marginEnd="8dp"
+            android:src="@drawable/ic_card_brand_master" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/gp_card_name"
+                style="@style/GP.Typography.Body1"
+                android:text="Mastercard Debit" />
+
+            <TextView
+                android:id="@+id/gp_card_number"
+                style="@style/GP.Typography.Label2"
+                android:text=".... 8217" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/gp_card_menu"
+            style="@style/GPIconBackground.Default"
+            android:src="@drawable/ic_overflow_menu" />
+    </LinearLayout>
+
+    <com.terminal3.gpcoreui.components.GPCardCVVField
+        android:id="@+id/gp_cvv_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        app:labelText="CVV" />
+
+</LinearLayout>

--- a/gpcoreui/src/main/res/values/colors.xml
+++ b/gpcoreui/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="gp_bg_error">#FFF5E5</color>
     <color name="gp_bg_press_secondary">#000000</color>
     <color name="gp_bg_payment_dark">#000000</color>
+    <color name="gp_bg_selected_card">#F0F4FF</color>
 
     <!-- Border Colors -->
     <color name="gp_border_payment">#D6E4FF</color>

--- a/gpcoreui/src/main/res/values/dimens.xml
+++ b/gpcoreui/src/main/res/values/dimens.xml
@@ -10,4 +10,6 @@
     <dimen name="gp_bottomsheet_max_height">500dp</dimen>
     <dimen name="gp_icon_size">24dp</dimen>
     <dimen name="gp_icon_margin_start">4dp</dimen>
+    <dimen name="gp_saved_card_padding">12dp</dimen>
+    <dimen name="gp_saved_card_corner">8dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- create `GPSavedCardView` with DEFAULT and SELECTED states
- add vector asset and backgrounds
- document the new component
- showcase the view in a new sample fragment and activity
- register the activity in the manifest
- update saved card fragment to manage multiple cards with single selection

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887c0dd4888330801826bf79455e20