### PR TITLE
Add docs and demo for secondary and error buttons

### DIFF
--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPButtonsFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPButtonsFragment.java
@@ -5,14 +5,17 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.terminal3.gpcoreui.components.GPErrorButton;
 import com.terminal3.gpcoreui.components.GPOutlinedButton;
 import com.terminal3.gpcoreui.components.GPPayAltoButton;
 import com.terminal3.gpcoreui.components.GPPrimaryButton;
+import com.terminal3.gpcoreui.components.GPSecondaryButton;
 import com.terminal3.gpcoreui.enums.GPButtonState;
 
 public class GPButtonsFragment extends Fragment {
@@ -29,6 +32,11 @@ public class GPButtonsFragment extends Fragment {
         GPPrimaryButton primary = view.findViewById(R.id.demoPrimaryButton);
         GPOutlinedButton outlined = view.findViewById(R.id.demoOutlinedButton);
         GPPayAltoButton payAlto = view.findViewById(R.id.demoPayAltoButton);
+        GPSecondaryButton secondary = view.findViewById(R.id.demoSecondaryButton);
+        GPErrorButton error = view.findViewById(R.id.demoErrorButton);
+        Button stateToggle = view.findViewById(R.id.btnStateToggle);
+
+        GPPrimaryButton[] buttons = new GPPrimaryButton[] {primary, outlined, secondary, error};
 
         primary.setOnClickListener(v -> {
             primary.setState(GPButtonState.LOADING);
@@ -48,5 +56,24 @@ public class GPButtonsFragment extends Fragment {
         payAlto.setOnClickListener( v -> {
             Log.d("GPButtonsFragment", "PayAlto button clicked");
         });
+
+        stateToggle.setOnClickListener(v -> {
+            for (GPPrimaryButton button : buttons) {
+                button.setState(nextState(button.getState()));
+            }
+        });
+    }
+
+    private GPButtonState nextState(GPButtonState state) {
+        switch (state) {
+            case DEFAULT:
+                return GPButtonState.LOADING;
+            case LOADING:
+                return GPButtonState.INACTIVE;
+            case INACTIVE:
+                return GPButtonState.PRESS;
+            default:
+                return GPButtonState.DEFAULT;
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_buttons.xml
+++ b/app/src/main/res/layout/fragment_buttons.xml
@@ -40,5 +40,26 @@
             app:imageSrc="@drawable/ic_pw_logo"
             app:title="iDEAL" />
 
+        <com.terminal3.gpcoreui.components.GPSecondaryButton
+            android:id="@+id/demoSecondaryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Secondary Button" />
+
+        <com.terminal3.gpcoreui.components.GPErrorButton
+            android:id="@+id/demoErrorButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Error Button" />
+
+        <Button
+            android:id="@+id/btnStateToggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Next State" />
+
     </LinearLayout>
 </LinearLayout>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -11,6 +11,8 @@ This overview lists all widgets included in the `gpcoreui` library. Every class 
 - [GPDynamicForm](components/GPDynamicForm.md)
 - [GPPrimaryButton](components/GPPrimaryButton.md)
 - [GPOutlinedButton](components/GPOutlinedButton.md)
+- [GPSecondaryButton](components/GPSecondaryButton.md)
+- [GPErrorButton](components/GPErrorButton.md)
 - [GPSavedCardView](components/GPSavedCardView.md)
 - [GPConfirmationBottomSheetFragment](components/GPConfirmationBottomSheetFragment.md)
 - [GPFooterTermsView](components/GPFooterTermsView.md)

--- a/docs/components/GPErrorButton.md
+++ b/docs/components/GPErrorButton.md
@@ -1,0 +1,27 @@
+# GPErrorButton
+
+## 1. Introduction
+`GPErrorButton` is a warning-styled action button used for error or destructive operations. It extends `GPPrimaryButton` and supports the same API.
+
+## 2. Params definition
+No custom XML attributes. Use `android:text` for the label.
+
+## 3. How to use in XML
+```xml
+<com.terminal3.gpcoreui.components.GPErrorButton
+    android:id="@+id/btnError"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:text="Error" />
+```
+
+## 4. How to use in Activity / Fragment
+```java
+GPErrorButton button = findViewById(R.id.btnError);
+button.setState(GPButtonState.LOADING);
+```
+
+## 5. How to interact with the UI component
+- Change state via `setState(GPButtonState)`
+- Check current state with `getState()`
+- Update text using `setText(CharSequence)`

--- a/docs/components/GPSecondaryButton.md
+++ b/docs/components/GPSecondaryButton.md
@@ -1,0 +1,27 @@
+# GPSecondaryButton
+
+## 1. Introduction
+`GPSecondaryButton` provides a lighter style for secondary actions. It inherits all behaviour from `GPPrimaryButton` and supports the same states.
+
+## 2. Params definition
+This component exposes no custom XML attributes. Use `android:text` to set the label.
+
+## 3. How to use in XML
+```xml
+<com.terminal3.gpcoreui.components.GPSecondaryButton
+    android:id="@+id/btnSecondary"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:text="Secondary" />
+```
+
+## 4. How to use in Activity / Fragment
+```java
+GPSecondaryButton button = findViewById(R.id.btnSecondary);
+button.setState(GPButtonState.INACTIVE);
+```
+
+## 5. How to interact with the UI component
+- Update state via `setState(GPButtonState)`
+- Get current state with `getState()`
+- Change text using `setText(CharSequence)`


### PR DESCRIPTION
## Summary
- Document GPSecondaryButton and GPErrorButton
- Show new buttons in demo fragment with state toggling

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904b1695ac83309e656ba6e047d033