### PR TITLE
Add validator handling for dynamic form group fields

### DIFF
--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPFormStepFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPFormStepFragment.java
@@ -1,7 +1,6 @@
 package com.terminal3.t3gamepaysdkcoreui;
 
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,14 +11,10 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.terminal3.gpcoreui.components.GPDynamicForm;
-import com.terminal3.gpcoreui.components.GPOptionView;
 import com.terminal3.gpcoreui.enums.GPOptionType;
 import com.terminal3.gpcoreui.models.GPOption;
-import com.terminal3.gpcoreui.models.GPOptionValidation;
 import com.terminal3.gpcoreui.utils.GPHelper;
 import com.terminal3.gpcoreui.utils.validator.GPValidator;
-import com.terminal3.gpcoreui.utils.validator.rules.GPRegexRule;
-import com.terminal3.gpcoreui.utils.validator.rules.GPRequiredRule;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -64,6 +59,7 @@ public class GPFormStepFragment extends Fragment {
         GPPrimaryButton btnNext = view.findViewById(R.id.btnNext);
 
         validator = new GPValidator.Builder().setAutoDisplayError(true).build();
+        form.setValidator(validator);
 
         int resId = getArguments() != null ? getArguments().getInt(ARG_JSON_RES) : 0;
         if (resId != 0) {
@@ -80,7 +76,6 @@ public class GPFormStepFragment extends Fragment {
                     }
                 });
             } else {
-                setupValidation(options);
                 btnNext.setOnClickListener(v -> {
                     if (validator.validate().getAllErrors().isEmpty()) {
                         if (stepListener != null) {
@@ -89,22 +84,6 @@ public class GPFormStepFragment extends Fragment {
                     }
                 });
             }
-        }
-    }
-
-    private void setupValidation(List<GPOption> options) {
-        for (GPOption option : options) {
-            if (option.getType() == GPOptionType.REDIRECT) continue;
-            GPOptionView view = form.getOptionView(option.getId());
-            List<GPOptionValidation> validations = option.getValidations();
-            List<com.terminal3.gpcoreui.utils.validator.GPValidationRule> rules = new ArrayList<>();
-            rules.add(new GPRequiredRule(option.getLabel() + " is required"));
-            for (GPOptionValidation val : validations) {
-                if (!TextUtils.isEmpty(val.getRegex())) {
-                    rules.add(new GPRegexRule(val.getRegex(), val.getMessage()));
-                }
-            }
-            validator.addRules(view, rules);
         }
     }
 

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/GPValidator.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/GPValidator.java
@@ -43,6 +43,15 @@ public class GPValidator {
         addRules(field, rules);
     }
 
+    /**
+     * Removes all validation rules associated with the given field.
+     *
+     * @param field The {@link GPValidatable} field to remove from validation tracking.
+     */
+    public void removeField(GPValidatable field) {
+        validationRules.remove(field);
+    }
+
     public GPValidationResult validate() {
         Map<GPValidatable, List<String>> errors = new HashMap<>();
 


### PR DESCRIPTION
## Summary
- integrate GPValidator into GPDynamicForm and manage group field rules when options change
- allow GPValidator to remove rules for dynamic fields
- hook sample fragment into new validation handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab6233fa88330a82eb01e974679c4