### PR TITLE
Add transaction review view and example fragment

### DIFF
--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPMainFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPMainFragment.java
@@ -24,7 +24,7 @@ public class GPMainFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         ListView listView = view.findViewById(R.id.listOptions);
-        String[] items = new String[] {"Input Fields", "Buttons", "Dynamic Form", "Saved Cards", "PayAlto Buttons", "Polling View Test"};
+        String[] items = new String[] {"Input Fields", "Buttons", "Dynamic Form", "Saved Cards", "PayAlto Buttons", "Polling View Test", "Transaction Under Review"};
         ArrayAdapter<String> adapter = new ArrayAdapter<>(requireContext(), android.R.layout.simple_list_item_1, items);
         listView.setAdapter(adapter);
 
@@ -49,6 +49,9 @@ public class GPMainFragment extends Fragment {
                         break;
                     case 5:
                         ((GPMainActivity) requireActivity()).showFragment(new GPPollingTestFragment(), true);
+                        break;
+                    case 6:
+                        ((GPMainActivity) requireActivity()).showFragment(new GPTransactionUnderReviewFragment(), true);
                         break;
                 }
             }

--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPTransactionUnderReviewFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPTransactionUnderReviewFragment.java
@@ -1,0 +1,28 @@
+package com.terminal3.t3gamepaysdkcoreui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.terminal3.gpcoreui.views.GPTransactionUnderReviewView;
+
+public class GPTransactionUnderReviewFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_transaction_under_review, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        GPTransactionUnderReviewView reviewView = view.findViewById(R.id.transactionUnderReviewView);
+        reviewView.setOnCloseClickListener(v -> requireActivity().getSupportFragmentManager().popBackStack());
+    }
+}

--- a/app/src/main/res/layout/fragment_transaction_under_review.xml
+++ b/app/src/main/res/layout/fragment_transaction_under_review.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.terminal3.gpcoreui.views.GPTransactionUnderReviewView
+        android:id="@+id/transactionUnderReviewView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -18,6 +18,7 @@ This overview lists all widgets included in the `gpcoreui` library. Every class 
 - [GPFooterTermsView](components/GPFooterTermsView.md)
 - [GPPayAltoButton](components/GPPayAltoButton.md)
 - [GPRedirectionView](components/GPRedirectionView.md)
+- [GPTransactionUnderReviewView](components/GPTransactionUnderReviewView.md)
 
 Each component document follows the same structure:
 1. Introduction

--- a/docs/components/GPTransactionUnderReviewView.md
+++ b/docs/components/GPTransactionUnderReviewView.md
@@ -1,0 +1,24 @@
+# GPTransactionUnderReviewView
+
+## 1. Introduction
+`GPTransactionUnderReviewView` displays a centered progress indicator with title and subtitle text and includes a close button in the top-right corner.
+
+## 2. Params definition
+This view exposes no custom XML attributes. Use setters to change texts or handle the close action.
+
+## 3. How to use in XML
+```xml
+<com.terminal3.gpcoreui.views.GPTransactionUnderReviewView
+    android:id="@+id/reviewView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+```
+
+## 4. How to use in Activity / Fragment
+```java
+GPTransactionUnderReviewView view = findViewById(R.id.reviewView);
+view.setOnCloseClickListener(v -> finish());
+```
+
+## 5. How to interact with the UI component
+Use `setTitleText`, `setSubtitleText`, and `setOnCloseClickListener` to customize the view.

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/views/GPTransactionUnderReviewView.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/views/GPTransactionUnderReviewView.java
@@ -1,0 +1,71 @@
+package com.terminal3.gpcoreui.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import com.terminal3.gpcoreui.R;
+
+public class GPTransactionUnderReviewView extends FrameLayout {
+
+    //region Fields
+    public ProgressBar progressIndicator;
+    public TextView titleText;
+    public TextView subtitleText;
+    public ImageButton closeButton;
+    //endregion
+
+    //region Constructors
+    public GPTransactionUnderReviewView(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public GPTransactionUnderReviewView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public GPTransactionUnderReviewView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+    //endregion
+
+    //region Initialization
+    private void init(Context context) {
+        LayoutInflater.from(context).inflate(R.layout.view_gp_transaction_under_review, this, true);
+        progressIndicator = findViewById(R.id.progressIndicator);
+        titleText = findViewById(R.id.titleText);
+        subtitleText = findViewById(R.id.subtitleText);
+        closeButton = findViewById(R.id.closeButton);
+    }
+    //endregion
+
+    //region Public API
+    public void setTitleText(String title) {
+        if (titleText != null) {
+            titleText.setText(title);
+        }
+    }
+
+    public void setSubtitleText(String subtitle) {
+        if (subtitleText != null) {
+            subtitleText.setText(subtitle);
+        }
+    }
+
+    public void setOnCloseClickListener(@Nullable OnClickListener listener) {
+        if (closeButton != null) {
+            closeButton.setOnClickListener(listener);
+        }
+    }
+    //endregion
+}

--- a/gpcoreui/src/main/res/drawable/gp_transaction_progress.xml
+++ b/gpcoreui/src/main/res/drawable/gp_transaction_progress.xml
@@ -1,0 +1,15 @@
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromDegrees="0"
+    android:toDegrees="360">
+    <shape
+        android:shape="ring"
+        android:useLevel="false"
+        android:innerRadiusRatio="3"
+        android:thickness="4dp">
+        <gradient
+            android:type="sweep"
+            android:startColor="#CCCCCC"
+            android:endColor="#666666"
+            android:useLevel="false" />
+    </shape>
+</rotate>

--- a/gpcoreui/src/main/res/drawable/ic_close.xml
+++ b/gpcoreui/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#060B14"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/gpcoreui/src/main/res/layout/view_gp_transaction_under_review.xml
+++ b/gpcoreui/src/main/res/layout/view_gp_transaction_under_review.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageButton
+        android:id="@+id/closeButton"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="end|top"
+        android:layout_margin="16dp"
+        android:background="@android:color/transparent"
+        android:contentDescription="@string/gp_close"
+        android:src="@drawable/ic_close" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+
+        <ProgressBar
+            android:id="@+id/progressIndicator"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginBottom="24dp"
+            android:indeterminate="true"
+            android:indeterminateDrawable="@drawable/gp_transaction_progress" />
+
+        <TextView
+            android:id="@+id/titleText"
+            style="@style/GP.Typography.Heading2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:gravity="center"
+            android:text="Transaction under review"
+            android:textAlignment="center"
+            android:textColor="@color/gp_text_primary" />
+
+        <TextView
+            android:id="@+id/subtitleText"
+            style="@style/GP.Typography.Body1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Please wait while your transaction is being reviewed"
+            android:textAlignment="center"
+            android:textColor="@color/gp_text_secondary" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/gpcoreui/src/main/res/values/strings.xml
+++ b/gpcoreui/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="gp_terms">Terms</string>
     <string name="gp_privacy">Privacy</string>
     <string name="gp_cvv">CVV</string>
+    <string name="gp_close">Close</string>
 </resources>


### PR DESCRIPTION
## Summary
- add GPTransactionUnderReviewView with centered progress, title and subtitle, plus top-right close button
- document the new component and expose XML/Java APIs
- showcase the view in example app via GPTransactionUnderReviewFragment

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab7f38f488330848b291ea18fa204