### PR TITLE
Add getAllValues to dynamic form

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To build forms dynamically, use `GPDynamicForm`:
 GPDynamicForm form = findViewById(R.id.dynamicForm);
 form.setOptions(serverOptions);
 Map<String, String> values = form.getValues();
+// Or form.getAllValues() to include hidden fields
 ```
 
 See [`docs/COMPONENTS.md`](docs/COMPONENTS.md) for an index of available widgets. Each component has its own document describing parameters and usage.

--- a/docs/components/GPDynamicForm.md
+++ b/docs/components/GPDynamicForm.md
@@ -15,7 +15,8 @@ form.setOnFormValueChangedListener((id, value) -> {
 });
 ```
 
-Use `getValues()` to retrieve all option values at once.
+Use `getValues()` to retrieve values for currently displayed options.
+Call `getAllValues()` to include hidden options with empty values.
 
 ## 3. Grouped Fields
 


### PR DESCRIPTION
## Summary
- Add `getAllValues` to `GPDynamicForm` to return values for all options, even hidden ones
- Track all options when setting form options
- Document new retrieval method

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c1ddfd3688330907913b4d178ad4a