### PR TITLE
Add TEL input type support and fix regex validation crashes

### DIFF
--- a/app/src/main/res/raw/form_step1.json
+++ b/app/src/main/res/raw/form_step1.json
@@ -41,6 +41,32 @@
                 "properties": [],
                 "name": "epin",
                 "type": "epin"
+            },
+            {
+                "label": "Test Invalid Regex",
+                "value": "",
+                "validation": [
+                    {
+                        "regex": "^[0-9]{}$",
+                        "message": "This field has invalid regex from backend"
+                    }
+                ],
+                "properties": [],
+                "name": "test_invalid_regex",
+                "type": "text"
+            },
+            {
+                "label": "Phone number",
+                "value": "",
+                "validation": [
+                    {
+                        "regex": "^[0-9]{10}$",
+                        "message": "Please enter a 10 digit number"
+                    }
+                ],
+                "properties": [],
+                "name": "telNo",
+                "type": "tel"
             }
         ]
     }

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDefaultEditText.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDefaultEditText.java
@@ -3,7 +3,6 @@ package com.terminal3.gpcoreui.components;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 
 import androidx.appcompat.widget.AppCompatEditText;
@@ -80,7 +79,6 @@ public class GPDefaultEditText extends AppCompatEditText {
         if (state == currentState) return;
         currentState = state;
         setBackgroundState(state);
-        Log.i("GPDefaultEditText", "setState: " + state);
     }
 
     public GPInputState getState() {
@@ -88,7 +86,6 @@ public class GPDefaultEditText extends AppCompatEditText {
     }
 
     public void setErrorMessage(String message) {
-        Log.i("GPDefaultEditText", "setErrorMessage: " + message);
         errorMessage = message;
         setState(GPInputState.ERROR);
     }

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDefaultInputContainer.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDefaultInputContainer.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
@@ -227,12 +226,10 @@ public class GPDefaultInputContainer extends LinearLayout implements GPOptionVie
     public String getInput() {
         if (null == _gpTextWatcher) {
             if (null == getEditText().getText()) return "";
-            Log.d("GPDefaultInputContainer", "getInput: " + getEditText().getText().toString());
             return getEditText().getText().toString();
         }
         else {
             String input = _gpTextWatcher.getRealValue();
-            Log.d("GPDefaultInputContainer", "getInput: " + input);
             return input;
         }
     }

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDynamicForm.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPDynamicForm.java
@@ -239,6 +239,8 @@ public class GPDynamicForm extends LinearLayout implements GPOptionView.OnOption
             view = input;
             if (option.getType() == GPOptionType.EPIN) {
                 input.addTextWatcher(new GPEpinTextWatcher());
+            } else if (option.getType() == GPOptionType.TEL) {
+                input.getEditText().setInputType(android.text.InputType.TYPE_CLASS_PHONE);
             }
         }
         return view;

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPPrimaryButton.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/components/GPPrimaryButton.java
@@ -2,7 +2,6 @@ package com.terminal3.gpcoreui.components;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.widget.Button;

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/GPOptionType.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/enums/GPOptionType.java
@@ -13,5 +13,7 @@ public enum GPOptionType {
     /** Redirect action */
     REDIRECT,
     /** Group of options linked to a dropdown */
-    GROUP
+    GROUP,
+    /** Phone number input field */
+    TEL
 }

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/models/GPOption.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/models/GPOption.java
@@ -68,6 +68,8 @@ public class GPOption {
             type = GPOptionType.REDIRECT;
         } else if ("group".equalsIgnoreCase(typeStr)) {
             type = GPOptionType.GROUP;
+        } else if ("tel".equalsIgnoreCase(typeStr)) {
+            type = GPOptionType.TEL;
         } else {
             type = GPOptionType.INPUT_FIELD;
         }

--- a/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRule.java
+++ b/gpcoreui/src/main/java/com/terminal3/gpcoreui/utils/validator/rules/GPRegexRule.java
@@ -1,12 +1,13 @@
 package com.terminal3.gpcoreui.utils.validator.rules;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Validation rule based on a regular expression.
  */
 public class GPRegexRule extends GPBaseRule {
-    private final Pattern pattern;
+    private Pattern pattern;
 
     /**
      * Creates a new regex rule.
@@ -16,7 +17,11 @@ public class GPRegexRule extends GPBaseRule {
      */
     public GPRegexRule(String regex, String errorMessage) {
         super(errorMessage);
-        this.pattern = Pattern.compile(regex);
+        try {
+            this.pattern = Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            this.pattern = Pattern.compile(".*");
+        }
     }
 
     @Override


### PR DESCRIPTION
- Add TEL enum to GPOptionType for phone number inputs
- Update GPOption.fromJson to handle 'tel' type from backend
- Set phone keyboard input type for TEL fields in GPDynamicForm
- Fix GPRegexRule crash with malformed regex patterns by using fallback pattern '.*'
- Remove all Log statements from gpcoreui module for production
- Add test cases for both TEL input and invalid regex handling