### PR TITLE
Add Fragments for GPAgreementTextView

### DIFF
--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPAgreementTextViewFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPAgreementTextViewFragment.java
@@ -1,0 +1,35 @@
+package com.terminal3.t3gamepaysdkcoreui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.terminal3.gpcoreui.components.GPAgreementTextView;
+
+public class GPAgreementTextViewFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_agreement_text_view, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        
+        GPAgreementTextView agreementTextView = view.findViewById(R.id.agreementTextView);
+        agreementTextView.configure(
+                "Terms of Service",
+                "https://www.fasterpay.com/terms-of-service",
+                "Privacy Policy", 
+                "https://www.fasterpay.com/privacy-policy",
+                "FasterPay"
+        );
+    }
+}

--- a/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPCardRemovalFragment.java
+++ b/app/src/main/java/com/terminal3/t3gamepaysdkcoreui/GPCardRemovalFragment.java
@@ -1,0 +1,53 @@
+package com.terminal3.t3gamepaysdkcoreui;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.terminal3.gpcoreui.components.GPConfirmationBottomSheetFragment;
+
+public class GPCardRemovalFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_card_removal, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        
+        Button testButton = view.findViewById(R.id.btnTestCardRemoval);
+        testButton.setOnClickListener(v -> showCardRemovalConfirmation());
+    }
+
+    private void showCardRemovalConfirmation() {
+        GPConfirmationBottomSheetFragment sheet = new GPConfirmationBottomSheetFragment();
+        sheet.setupCardRemovalConfirmation("Mastercard", "Credit", "8217");
+        sheet.setOnDecisionListener(new GPConfirmationBottomSheetFragment.OnDecisionListener() {
+            @Override
+            public void onPositiveClick() {
+                // Not used in this case
+            }
+
+            @Override
+            public void onDestructiveClick() {
+                Toast.makeText(getContext(), "Card removed successfully", Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
+            public void onCancel() {
+                Toast.makeText(getContext(), "Card removal cancelled", Toast.LENGTH_SHORT).show();
+            }
+        });
+        sheet.show(getParentFragmentManager(), "card_removal_confirm");
+    }
+}

--- a/app/src/main/res/layout/fragment_agreement_text_view.xml
+++ b/app/src/main/res/layout/fragment_agreement_text_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="Agreement Text View"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="GPAgreementTextView Test"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <com.terminal3.gpcoreui.components.GPAgreementTextView
+        android:id="@+id/agreementTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_card_removal.xml
+++ b/app/src/main/res/layout/fragment_card_removal.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="Card Removal Test"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="GPConfirmationBottomSheetFragment Test"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:gravity="center" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Click the button below to test the card removal confirmation bottom sheet."
+        android:textSize="14sp"
+        android:gravity="center" />
+
+    <Button
+        android:id="@+id/btnTestCardRemoval"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Test Card Removal Confirmation"
+        android:textAllCaps="false" />
+
+</LinearLayout>


### PR DESCRIPTION
- Create `GPAgreementTextViewFragment` to demonstrate `GPAgreementTextView` usage.
- Create `GPCardRemovalFragment` to demonstrate `GPConfirmationBottomSheetFragment` for card removal confirmation.
- Add corresponding XML layout files `fragment_agreement_text_view.xml` and `fragment_card_removal.xml`.
- Configure `GPAgreementTextView` with sample terms of service and privacy policy links.
- Implement logic in `GPCardRemovalFragment` to show the confirmation bottom sheet with sample card details and handle user decisions with toasts.